### PR TITLE
Removes usernames from word cloud

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 from collections import Counter
-from nltk.tokenize import TweetTokenizer
 import sentiment
 import twitter
 import word_cloud
@@ -18,8 +17,7 @@ def main(handle):
         print("*****************************")
         count[res] += 1
 
-        tweet_tokens = TweetTokenizer().tokenize(tweet)
-        wc.add(tweet_tokens)
+        wc.add(tweet)
 
     print("\nOverall sentiment:")
     print(count)

--- a/word_cloud.py
+++ b/word_cloud.py
@@ -7,14 +7,17 @@ from nltk.tokenize import TweetTokenizer
 class WordCloud(object):
 
     def __init__(self):
+        self.tokeniser = TweetTokenizer()
         tweet_data = " ".join(twitter_samples.strings("tweets.20150430-223406.json"))
-        tweet_words = TweetTokenizer().tokenize(tweet_data)
+        tweet_words = self.tokeniser.tokenize(tweet_data.lower())
         self.reference = Counter(tweet_words)
         self.words = Counter()
 
-    def add(self, new_words):
+    def add(self, tweet):
+        new_words = self.tokeniser.tokenize(tweet.lower())
         for word in new_words:
-            self.words[word] += 1
+            if not word.startswith("@"):
+                self.words[word] += 1
 
     def display(self, limit=5):
         tf_idf = []


### PR DESCRIPTION
Before this, usernames appeared high up in the list as individuals tweet
at the same few accounts frequently, eg their favourite newspaper or
sportsteam, and these usernames rarely appeared in the sample data,
giving them a high weight under the tf-idf system.

It would be interesting to see what effect removing this change has
on the results once we switch to a topic focused system rather than
a specific user based system. After this change, any highly scoring
usernames would give insight into what accounts people from one side
interact with more than the other side.