### PR TITLE
Excludes tweets with either 0 or >1 relevant hashtags

### DIFF
--- a/classifier/server.py
+++ b/classifier/server.py
@@ -28,13 +28,11 @@ def classify_tweet():
     data = request.get_json()
 
     sentiment = classi.classify(data["text"]) == "positive"
-    viewpoint = "#repealthe8th" in data["text"].lower()
-    # TODO - determine viewpoint better than this...
 
     # Splitting up command and values helps prevent SQL injection
     cursor.execute("INSERT INTO sentiment (tweet_id, sentiment, timestamp, viewpoint)"
                    "VALUES (%s, %s, to_timestamp(%s), %s);",
-                   (data["id"], sentiment, data["timestamp"], viewpoint))
+                   (data["id"], sentiment, data["timestamp"], data["viewpoint"]))
     db_con.commit()
 
     print(data["text"])

--- a/streamer/streamer.py
+++ b/streamer/streamer.py
@@ -25,7 +25,8 @@ class TwitterStreamer(tweepy.StreamListener):
             "id": status.id_str,
             # convert from millisconds to correct epoch format
             "timestamp": int(status.timestamp_ms)//1000,
-            "text": tweet_text
+            "text": tweet_text,
+            "viewpoint": "repealthe8th" in tweet_text.lower()
         }
 
         self.executor.submit(self.send_data_onward, data)

--- a/streamer/tweet_parsing_utils.py
+++ b/streamer/tweet_parsing_utils.py
@@ -4,6 +4,14 @@ def is_tweet_valid(status):
     if status.user.time_zone not in ["Dublin", None]:
         # if we know they're not in Ireland, should they get a say?
         return False
+
+    tracked_hts = {"repealthe8th", "savethe8th"}
+    used_hts = [ht["text"].lower() for ht in status.entities["hashtags"]]
+    if len(tracked_hts.intersection(used_hts)) != 1:
+        # either they didn't contain any of the hashtags we're searching for or
+        # they contain more than one hashtag we're looking for which would be noise
+        return False
+
     return True
 
 


### PR DESCRIPTION
Removing tweets with 0 hashtags because we don't want them in the
first place. This seems to happen if someone's replying to a
tweet containing the hashtag but they don't put it in their tweet.

Removing tweets with more than 1 hashtag because it means they said
both repeal and save so we don't know who to allocate it to. In
future if we start following more hashtags we might rethink this
decision but for now it's best to leave them out.