### PR TITLE
Removes old tweets from DB

### DIFF
--- a/analyser/analyser.py
+++ b/analyser/analyser.py
@@ -15,6 +15,7 @@ class Analyser(object):
     def run_infinitely(self, period=60):
         while True:
             self.get_daily_avg_sentiment_by_viewpoint()
+            self.prune_old_tweets()
             time.sleep(period)
 
     def get_daily_avg_sentiment_by_viewpoint(self):
@@ -31,6 +32,11 @@ class Analyser(object):
         self.redis.hmset("vp:senti", vp_senti)
         self.redis.hmset("vn:senti", vn_senti)
         self.redis.set("lastUpdated", time.time())
+
+    def prune_old_tweets(self):
+        with open("prune_old_tweets.sql") as sql:
+            self.db_cursor.execute(sql.read())
+        self.db_con.commit()
 
     @staticmethod
     def connect_to_db():

--- a/analyser/prune_old_tweets.sql
+++ b/analyser/prune_old_tweets.sql
@@ -1,0 +1,22 @@
+DELETE FROM tweet
+WHERE tweet_id NOT IN (
+
+  (
+    SELECT tweet_id
+    FROM tweet
+    WHERE viewpoint = FALSE
+    ORDER BY timestamp DESC
+    LIMIT 500
+  )
+
+  UNION
+
+  (
+    SELECT tweet_id
+    FROM tweet
+    WHERE viewpoint = TRUE
+    ORDER BY timestamp DESC
+    LIMIT 500
+  )
+
+);


### PR DESCRIPTION
We'll only be using the last N tweets to create word clouds
so no point storing tweets outside that. We're keeping the
500 most recent tweets in both categories and deleting the
rest to save disk space.