### PR TITLE
Adds relative daily tweet count graph to static analyser

### DIFF
--- a/analyser/relative_daily_tweet_count_by_viewpoint.sql
+++ b/analyser/relative_daily_tweet_count_by_viewpoint.sql
@@ -1,0 +1,24 @@
+SELECT daily_tweet_count.timestamp,
+       daily_tweet_count.viewpoint,
+       daily_tweet_count.count / avg_daily_tweet_count_by_viewpoint.average
+
+FROM
+  (
+      SELECT timestamp::date, viewpoint, COUNT(*) as count
+      FROM sentiment
+      GROUP BY timestamp::date, viewpoint
+  ) as daily_tweet_count
+  ,
+  (
+      SELECT avg(daily_total) as average, x.viewpoint
+      FROM (
+            SELECT COUNT(*) as daily_total, viewpoint
+            FROM sentiment
+            GROUP BY timestamp::date, viewpoint
+      ) as x
+      GROUP BY x.viewpoint
+  ) as avg_daily_tweet_count_by_viewpoint
+
+WHERE avg_daily_tweet_count_by_viewpoint.viewpoint = daily_tweet_count.viewpoint
+
+ORDER BY 1, 2;

--- a/analyser/static_analyser.py
+++ b/analyser/static_analyser.py
@@ -45,6 +45,17 @@ class StaticAnalyser(object):
                       [res[2] for res in results if not res[1]]],
                   legend=["Pro-Choice Tweets", "Pro-Life Tweets"])
 
+    def get_relative_daily_tweet_count_by_viewpoint(self):
+        with open("relative_daily_tweet_count_by_viewpoint.sql") as query:
+            self.db_cursor.execute(query.read())
+
+        results = self.db_cursor.fetchall()
+        self.plot("relative_daily_tweet_count_by_viewpoint",
+                  x=[res[0] for res in results if res[1]],
+                  ys=[[res[2] for res in results if res[1]],
+                      [res[2] for res in results if not res[1]]],
+                  legend=["#RepealThe8th Tweets", "#SaveThe8th Tweets"])
+
     @staticmethod
     def plot(image_name, x, ys, legend):
         fig, ax = plt.subplots(figsize=(15, 8))
@@ -81,3 +92,4 @@ if __name__ == '__main__':
     sa.get_daily_tweet_count()
     sa.get_daily_tweet_count_by_viewpoint()
     sa.get_daily_avg_sentiment_by_viewpoint()
+    sa.get_relative_daily_tweet_count_by_viewpoint()


### PR DESCRIPTION
Rather than just charting both viewpoint's daily tweet count, which
isn't great due to the difference in data volumes, this graph
charts each viewpoint's daily tweet total divided by that viewpoint's
average daily tweet count. It allows us to directly compare the
two viewpoint's activity, without dealing with a large difference
in totals.