### PR TITLE
Adds 'links' to the wordcloud terms

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -14,10 +14,13 @@
             height: 30vh;
         }
         .cloud-word {
+            cursor: pointer;
             transition: text-shadow .3s;
         }
         .cloud-word:hover {
             text-shadow: 0 0 15px #ffffff;
+            text-decoration: underline;
+
         }
     </style>
 </head>
@@ -64,10 +67,10 @@
     "use strict";
     window.onload = () => {
         const lc = new LineChart(document.getElementById('sentiment-graph'));
-        const repealCloud = new SentiCloud(document.getElementById("repeal-cloud"), {
+        const repealCloud = new SentiCloud("#repealthe8th", document.getElementById("repeal-cloud"), {
                 backgroundColor: '#000000'
         });
-        const saveCloud = new SentiCloud(document.getElementById("save-cloud"), {
+        const saveCloud = new SentiCloud("#savethe8th", document.getElementById("save-cloud"), {
             backgroundColor: '#ed207b'
         });
 

--- a/web/sentiCloud.js
+++ b/web/sentiCloud.js
@@ -1,9 +1,9 @@
 'use strict';
 
-/* global WordCloud:false */
+/* global WordCloud:false window:false */
 
 class SentiCloud { // eslint-disable-line no-unused-vars
-    constructor(element, extraConfig) {
+    constructor(name, element, extraConfig) {
         const defaultConfig = {
             fontFamily: 'Helvetica',
             color: '#ffffff',
@@ -14,6 +14,11 @@ class SentiCloud { // eslint-disable-line no-unused-vars
             weightFactor: 1,
             gridSize: 12,
             classes: 'cloud-word',
+            click: (item) => {
+                const query = encodeURIComponent(`${name} ${item[0]}`);
+                const url = `https://twitter.com/search?q=${query}`;
+                window.open(url, item[0]);
+            },
         };
 
         this.config = Object.assign(defaultConfig, extraConfig);


### PR DESCRIPTION
Ok so they're technically not links, they're on click event handlers
that open a specified page when they're clicked. Close enough. Users
will click the term and a new tab will be opened showing the tweets
that term is occuring in.