### PR TITLE
Replaces tweets with relaxed chats for wordcloud benchmark

### DIFF
--- a/analyser/wordcloud.py
+++ b/analyser/wordcloud.py
@@ -1,6 +1,6 @@
 import operator
 from collections import Counter
-from nltk.corpus import twitter_samples
+from nltk.corpus import webtext
 
 
 class WordCloud(object):
@@ -53,5 +53,5 @@ class WordCloud(object):
 
 
 _normal_word_freq = Counter()
-[_normal_word_freq.update(WordCloud.parse_tweet(twt)) for twt in
- twitter_samples.strings("tweets.20150430-223406.json")]
+[_normal_word_freq.update(WordCloud.parse_tweet(text.split(":", maxsplit=1)[-1]))
+ for text in webtext.raw("overheard.txt").split("\n")]


### PR DESCRIPTION
This deals with the issues highlighted previously in that the
twitter corpus provided by the NLTK library is too politically
focused due to the data being collected during the UK general
election in 2015. This changes the benchmark to content of
conversations overheard and then transcribed. From looking
through the top words it's clear this is a much better dataset
to match everyday word usage.