### PR TITLE
Replaces 'angled' apostrophes with normal ones

### DIFF
--- a/analyser/wordcloud.py
+++ b/analyser/wordcloud.py
@@ -43,12 +43,14 @@ class WordCloud(object):
             .replace(")", " ") \
             .replace("[", " ") \
             .replace("]", " ") \
+            .replace("‘", "'") \
+            .replace("’", "'") \
             .replace("<", "&lt;") \
             .replace(">", "&gt;") \
             .split()
         words_wo_links = [w for w in words if not w.startswith("co/")]
         #  ^This removes Twitter shorthand URLs
-        words_wo_quots = [w.strip("'‘’/") for w in words_wo_links]
+        words_wo_quots = [w.strip("'/") for w in words_wo_links]
         return [w for w in words_wo_quots if len(w) > 1]
 
 


### PR DESCRIPTION
Some tweets use the angled apostrophes while the text corpus I'm
using just uses the normal one. This means they're considered
different words which isn't what we want. It makes sense to agree
on a single type to use everywhere so all apostrophes will now be
the normal kind.