### PR TITLE
Stops catching SQL errors - lets auto restart handle it instead

### DIFF
--- a/classifier/server.py
+++ b/classifier/server.py
@@ -29,19 +29,14 @@ def classify_tweet():
 
     sentiment = classi.classify(data["text"]) == "positive"
 
-    try:
-        # Splitting up command and values helps prevent SQL injection
-        cursor.execute("INSERT INTO sentiment (tweet_id, sentiment, timestamp, viewpoint)"
-                       "VALUES (%s, %s, to_timestamp(%s), %s);",
-                       (data["id"], sentiment, data["timestamp"], data["viewpoint"]))
-        cursor.execute("INSERT INTO tweet (tweet_id, tweet_text, timestamp, viewpoint)"
-                       "VALUES (%s, %s, to_timestamp(%s), %s);",
-                       (data["id"], data["text"], data["timestamp"], data["viewpoint"]))
-        db_con.commit()
-    except psycopg2.Error as e:
-        print("!!!!!!!!!!!!!!!!!!!!!")
-        print(e.pgerror)
-        print("!!!!!!!!!!!!!!!!!!!!!")
+    # Splitting up command and values helps prevent SQL injection
+    cursor.execute("INSERT INTO sentiment (tweet_id, sentiment, timestamp, viewpoint)"
+                   "VALUES (%s, %s, to_timestamp(%s), %s);",
+                   (data["id"], sentiment, data["timestamp"], data["viewpoint"]))
+    cursor.execute("INSERT INTO tweet (tweet_id, tweet_text, timestamp, viewpoint)"
+                   "VALUES (%s, %s, to_timestamp(%s), %s);",
+                   (data["id"], data["text"], data["timestamp"], data["viewpoint"]))
+    db_con.commit()
 
     print(data["text"])
     return "OK"


### PR DESCRIPTION
That mysterious SQL error that last occured a few months ago seems
to have poped up again. The verbose logging of the error message
I added in back then doesn't give any more clues, it just prints
'None'. I've removed the catching of SQL errors now to let
auto-restart handle the errors instead.